### PR TITLE
Remove incorrect SPI setting from BoardEnv.txt

### DIFF
--- a/src/modules/opiconfig/start_chroot_script
+++ b/src/modules/opiconfig/start_chroot_script
@@ -16,16 +16,3 @@ fi
 # shellcheck disable=SC1091
 source /common.sh
 install_cleanup_trap
-
-echo_green "Enable SPI interface on Orange Pi SBC's ..."
-
-# Step 1: Copy default config to backup file
-cp "${OPICONFIG_CONFIG_TXT_FILE}" "${OPICONFIG_CONFIG_BAK_FILE}"
-
-# Step 2: Enable SPI
-echo "overlays=spi" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-echo "spidevparam_spidev_spi_bus=1" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-echo "param_spidev_spi_cs=1" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-echo "param_spidev_max_freq=1000000" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-
-echo_green "Enable SPI interface on SB1 ... DONE!"


### PR DESCRIPTION
The correct way to have SPI is setting "overlays=spidev1_2" and that is already present as an option in the file. The script was also setting "overlays" at the end of BardoEnv.txt which would smash any "overlays" definition before in the file. It also removes the unnecessary creationof a backup file.