### PR TITLE
fix: use the BoardEnv.txt to enable spi on CB1

### DIFF
--- a/config/armbian/CB1
+++ b/config/armbian/CB1
@@ -20,4 +20,4 @@ export BASE_IMAGE_RESIZEROOT
 export DOWNLOAD_URL_CHECKSUM
 export DOWNLOAD_URL_IMAGE
 
-export MODULES="base,deb_namserver,passwordless_sudo,pkgupgrade(network,cb1config,klipper,node,is_req_preinstall,moonraker,opiconfig,ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,rpi_mcu,disable-services(hotspot_cb1),dfu-util),password-for-sudo),postrename"
+export MODULES="base,deb_namserver,passwordless_sudo,pkgupgrade(network,cb1config,klipper,node,is_req_preinstall,moonraker,cb1spi,ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,rpi_mcu,disable-services(hotspot_cb1),dfu-util),password-for-sudo),postrename"

--- a/src/modules/cb1spi/config
+++ b/src/modules/cb1spi/config
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#### CB1SPI - CB1 Configuration Module
+
+# Shebang for better file detection
+# shellcheck disable=all
+
+[ -n "$CB1SPI_CONFIG_TXT_FILE" ] || CB1SPI_CONFIG_TXT_FILE="/boot/BoardEnv.txt"
+[ -n "$CB1SPI_CONFIG_BAK_FILE" ] || CB1SPI_CONFIG_BAK_FILE="/boot/BoardEnv.txt.backup"

--- a/src/modules/cb1spi/start_chroot_script
+++ b/src/modules/cb1spi/start_chroot_script
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#### opiconfig - SB1 Configuration Module
+#### CB1SPI - SB1 Configuration Module
 #from https://www.reddit.com/r/BIGTREETECH/comments/xfom6n/comment/it32e6v/
 
 # shellcheck enable=require-variable-braces
@@ -17,15 +17,12 @@ fi
 source /common.sh
 install_cleanup_trap
 
-echo_green "Enable SPI interface on Orange Pi SBC's ..."
+echo_green "Enable SPI interface on CB1 SBC's ..."
 
 # Step 1: Copy default config to backup file
-cp "${OPICONFIG_CONFIG_TXT_FILE}" "${OPICONFIG_CONFIG_BAK_FILE}"
+cp "${CB1SPI_CONFIG_TXT_FILE}" "${CB1SPI_CONFIG_BAK_FILE}"
 
 # Step 2: Enable SPI
-echo "overlays=spi" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-echo "spidevparam_spidev_spi_bus=1" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-echo "param_spidev_spi_cs=1" >> "${OPICONFIG_CONFIG_TXT_FILE}"
-echo "param_spidev_max_freq=1000000" >> "${OPICONFIG_CONFIG_TXT_FILE}"
+sed -i 's/^#overlays=spidev1_2.*/overlays=spidev1_2/' "${CB1SPI_CONFIG_TXT_FILE}"
 
-echo_green "Enable SPI interface on SB1 ... DONE!"
+echo_green "Enable SPI interface on CB1 SBC ... DONE!"

--- a/src/modules/opiconfig/config
+++ b/src/modules/opiconfig/config
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-#### opiconfig - CB1 Configuration Module
-
-# Shebang for better file detection
-# shellcheck disable=all
-
-[ -n "$OPICONFIG_CONFIG_TXT_FILE" ] || OPICONFIG_CONFIG_TXT_FILE="/boot/BoardEnv.txt"
-[ -n "$OPICONFIG_CONFIG_BAK_FILE" ] || OPICONFIG_CONFIG_BAK_FILE="/boot/BoardEnv.txt.backup"


### PR DESCRIPTION
correctly fixes issue in https://github.com/Rat-OS/RatOS/pull/68