### PR TITLE
Renaming rpi_mcu to host_computer_mcu

### DIFF
--- a/config/armbian/CB1
+++ b/config/armbian/CB1
@@ -20,4 +20,4 @@ export BASE_IMAGE_RESIZEROOT
 export DOWNLOAD_URL_CHECKSUM
 export DOWNLOAD_URL_IMAGE
 
-export MODULES="base,deb_namserver,passwordless_sudo,pkgupgrade(network,cb1config,klipper,node,is_req_preinstall,moonraker,cb1spi,ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,rpi_mcu,disable-services(hotspot_cb1),dfu-util),password-for-sudo),postrename"
+export MODULES="base,deb_namserver,passwordless_sudo,pkgupgrade(network,cb1config,klipper,node,is_req_preinstall,moonraker,cb1spi,ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,host_computer_mcu,disable-services(hotspot_cb1),dfu-util),password-for-sudo),postrename"

--- a/config/armbian/default
+++ b/config/armbian/default
@@ -7,4 +7,4 @@ export BASE_IMAGE_RASPBIAN=no
 export BASE_IMAGE_ENLARGEROOT=1000
 export BASE_ARCH=arm64
 
-export MODULES="base,pkgupgrade(network,piconfig,klipper,node,is_req_preinstall,moonraker,mainsail,crowsnest,ratos(linear_movement_analysis,timelapse,klipperscreen,rpi_mcu,disable-services(hotspot),dfu-util),password-for-sudo),postrename"
+export MODULES="base,pkgupgrade(network,piconfig,klipper,node,is_req_preinstall,moonraker,mainsail,crowsnest,ratos(linear_movement_analysis,timelapse,klipperscreen,host_computer_mcu,disable-services(hotspot),dfu-util),password-for-sudo),postrename"

--- a/config/raspberry/default
+++ b/config/raspberry/default
@@ -3,7 +3,7 @@ BASE_IMAGE_RESIZEROOT=600
 # Compress not needed due compression done in workflow
 BASE_RELEASE_COMPRESS=no
 # Modules are valid for 32bit and 64bit images
-MODULES="base,pkgupgrade(network,piconfig,klipper,node,is_req_preinstall,moonraker,ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,rpi_mcu,disable-services(hotspot),dfu-util),password-for-sudo),postrename"
+MODULES="base,pkgupgrade(network,piconfig,klipper,node,is_req_preinstall,moonraker,ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,host_computer_mcu,disable-services(hotspot),dfu-util),password-for-sudo),postrename"
 # export Variables
 export BASE_IMAGE_ENLARGEROOT
 export BASE_IMAGE_RESIZEROOT

--- a/src/modules/host_computer_mcu/start_chroot_script
+++ b/src/modules/host_computer_mcu/start_chroot_script
@@ -7,11 +7,11 @@ set -xe
 source /common.sh
 install_cleanup_trap
 
-echo_green "Installing RPI MCU service"
+echo_green "Installing Host Computer MCU service"
 
 pushd /home/pi/klipper
-echo "flashing rpi-mcu"
-cp -f /home/pi/printer_data/config/RatOS/boards/rpi/firmware.config /home/pi/klipper/.config
+echo "flashing host-computer-mcu"
+cp -f /home/pi/printer_data/config/RatOS/boards/host-computer/firmware.config /home/pi/klipper/.config
 make olddefconfig
 make clean
 make flash


### PR DESCRIPTION
Genericizes the type of single-board computer in use by renaming from `rpi_mcu` to `host_computer_mcu`, and uses the term "host computer" where applicable.

Requires for Rat-OS/RatOS-configuration#132
Build will fail until the config changes are merged