### PR TITLE
Add support for Rock Pi 4b & 4 SE

### DIFF
--- a/config/armbian/rockpi4b
+++ b/config/armbian/rockpi4b
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+export BASE_ARCH="arm64"
+export BASE_IMAGE_ENLARGEROOT=10500
+export BASE_IMAGE_RESIZEROOT=600
+export BASE_ROOT_PARTITION=1
+export BASE_ADD_USER="yes"
+export BASE_USER="pi"
+export BASE_USER_PASSWORD="raspberry"
+export MODULES="base,deb_namserver,passwordless_sudo,pkgupgrade(network,rockpiconfig,klipper,node,is_req_preinstall,moonraker,disable-services(hotspot_nm),ratos(mainsail,crowsnest,linear_movement_analysis,timelapse,klipperscreen,host_computer_mcu,dfu-util),password-for-sudo),postrename"
+
+# Image source
+export DOWNLOAD_URL_CHECKSUM="http://armbian.chi.auroradev.org/dl/rockpi-4b/archive/Armbian_23.02.2_Rockpi-4b_bullseye_current_5.15.93.img.xz.sha"
+export DOWNLOAD_URL_IMAGE="http://armbian.chi.auroradev.org/dl/rockpi-4b/archive/Armbian_23.02.2_Rockpi-4b_bullseye_current_5.15.93.img.xz.torrent"

--- a/src/modules/hotspot_nm/config
+++ b/src/modules/hotspot_nm/config
@@ -1,0 +1,2 @@
+[ -n "$HOTSPOT_NM_SSID" ] || HOTSPOT_NM_SSID=RatOS
+[ -n "$HOTSPOT_NM_PSK" ] || HOTSPOT_NM_PSK=raspberry

--- a/src/modules/hotspot_nm/filesystem/root/etc/NetworkManager/dispatcher.d/10-ratos-hotspot
+++ b/src/modules/hotspot_nm/filesystem/root/etc/NetworkManager/dispatcher.d/10-ratos-hotspot
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl restart autohotspot.service

--- a/src/modules/hotspot_nm/filesystem/root/etc/default/dnsmasq
+++ b/src/modules/hotspot_nm/filesystem/root/etc/default/dnsmasq
@@ -1,0 +1,1 @@
+DNSMASQ_EXCEPT="lo"

--- a/src/modules/hotspot_nm/filesystem/root/etc/dnsmasq.d/wlan
+++ b/src/modules/hotspot_nm/filesystem/root/etc/dnsmasq.d/wlan
@@ -1,0 +1,5 @@
+interface=wlan0
+dhcp-range=192.168.50.2,192.168.50.254,1h
+dhcp-option=3
+leasefile-ro
+port=0

--- a/src/modules/hotspot_nm/filesystem/root/etc/systemd/system/autohotspot.service
+++ b/src/modules/hotspot_nm/filesystem/root/etc/systemd/system/autohotspot.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Fallback wifi hotspot service
+After=multi-user.target NetworkManager.service
+Wants=NetworkManager.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/autohotspotNM
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/hotspot_nm/filesystem/root/usr/bin/autohotspotNM
+++ b/src/modules/hotspot_nm/filesystem/root/usr/bin/autohotspotNM
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Hotspot for NetworkManager
+# Boots up a hotspot if no active connection is found
+# This service is meant to run on any network connection change
+# Written by Alfonso Corretti <acorretti at gmail dot com>
+# GPL V3
+########
+
+HOTSPOT_CON="Hotspot"
+HOTSPOT_SSID="%HOTSPOT_NM_SSID%"
+HOTSPOT_PSK="%HOTSPOT_NM_PSK%"
+
+# Ensure NetworkManager-dispatcher.service always remains started
+trap 'systemctl enable NetworkManager-dispatcher.service && systemctl start NetworkManager-dispatcher.service' EXIT
+
+# Exit removing the hotspot connection if there is an active connection
+ACTIVE_CONN=$(nmcli -f NAME,STATE con show --active | tail -n +2 | grep -Ev "^($HOTSPOT_CON)")
+if [[ ! -z "$ACTIVE_CONN" ]]
+then
+  echo "Active connection found ($ACTIVE_CONN) -- disabling hotspot"
+  nmcli con down $HOTSPOT_CON &>/dev/null
+  nmcli con delete $HOTSPOT_CON &>/dev/null
+  exit 0
+fi
+
+# Avoid self-triggering, we'll re-enable later
+systemctl disable NetworkManager-dispatcher.service
+systemctl stop NetworkManager-dispatcher.service
+
+# Attempt to connect to all known SSIDs
+# -- This is needed as RatOS-configurator wants to write the wifi config, then
+# ask for the hostname, then reboot -- and expects the connection to autostart.
+# NetworkManager's nmcli doesn't support this operation and expects the
+# connection to link up when declaring it.
+# By forcing its activation once, the autoconnect will come in effect.
+IFS=$'\n'
+read -a ssidlist <<< $(nmcli -t -f type,state,name con show | grep "802-11-wireless::" | grep -v Hotspot | cut -d ':' -f 3)
+for ssid in "${ssidlist[@]}"
+do
+  echo "Attempting to connect to '$ssid'..."
+  nmcli -w 10 con up "$ssid" && break
+done
+
+# Check for active connection again
+ACTIVE_WIFI=$(nmcli -f NAME,STATE con show --active | tail -n +2 | grep -Ev "^($HOTSPOT_CON)" | grep -Ev "activating $")
+if [[ -z "$ACTIVE_WIFI" ]]
+then
+  echo "No active connection found -- enabling hotspot"
+
+  # Add Hotspot connection
+  nmcli con add type wifi ifname wlan0 con-name $HOTSPOT_CON autoconnect yes ssid $HOTSPOT_SSID
+  nmcli con modify $HOTSPOT_CON 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared ipv4.addresses 192.168.50.1/24 ipv4.gateway 192.168.50.1
+  nmcli con modify $HOTSPOT_CON wifi-sec.key-mgmt wpa-psk
+  nmcli con modify $HOTSPOT_CON wifi-sec.psk "$HOTSPOT_PSK"
+  nmcli con up $HOTSPOT_CON
+else
+  echo "No need for hotspot! -- $ACTIVE_WIFI is active"
+fi
+
+# EXIT trap will re-enable & start NetworkManager-dispatcher.service

--- a/src/modules/hotspot_nm/filesystem/root/usr/bin/autohotspotNM
+++ b/src/modules/hotspot_nm/filesystem/root/usr/bin/autohotspotNM
@@ -9,6 +9,7 @@
 HOTSPOT_CON="Hotspot"
 HOTSPOT_SSID="%HOTSPOT_NM_SSID%"
 HOTSPOT_PSK="%HOTSPOT_NM_PSK%"
+WIFI_TIMEOUT=15
 
 # Ensure NetworkManager-dispatcher.service always remains started
 trap 'systemctl enable NetworkManager-dispatcher.service && systemctl start NetworkManager-dispatcher.service' EXIT
@@ -38,7 +39,7 @@ read -a ssidlist <<< $(nmcli -t -f type,state,name con show | grep "802-11-wirel
 for ssid in "${ssidlist[@]}"
 do
   echo "Attempting to connect to '$ssid'..."
-  nmcli -w 10 con up "$ssid" && break
+  nmcli -w $WIFI_TIMEOUT con up "$ssid" && break
 done
 
 # Check for active connection again

--- a/src/modules/hotspot_nm/start_chroot_script
+++ b/src/modules/hotspot_nm/start_chroot_script
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# RatOS Hotspot module for NetworkManager
+# Boots up a hotspot if no active connection is found
+# Written by Alfonso Corretti <acorretti at gmail dot com>
+# GPL V3
+########
+set -x
+set -e
+
+SCRIPT_FILE="/usr/bin/autohotspotNM"
+
+source /common.sh
+
+# Install dnsmasq-base as dhcp server and avahi-daemon as it's not included
+# on armbian. NOTE: It's required for this module to be loaded BEFORE the
+# 'ratos' module, otherwise the build will fail as ratos includes a modified
+# avahi-daemon.conf file and apt will interactively ask what to do, even if the
+# DEBIAN_FRONTEND is set to uninteractive.
+check_install_pkgs dnsmasq-base avahi-daemon
+
+unpack /filesystem/root /
+
+# Replace config vars
+sed -i s"/%HOTSPOT_NM_SSID%/$HOTSPOT_NM_SSID/g" $SCRIPT_FILE
+sed -i s"/%HOTSPOT_NM_PSK%/$HOTSPOT_NM_PSK/g" $SCRIPT_FILE
+
+# Make hotspot script executable
+chmod a+x /usr/bin/autohotspotNM
+# Make watch script executable
+chmod a+x /etc/NetworkManager/dispatcher.d/10-ratos-hotspot
+
+# Enable the NetworkManager dispatcher service
+systemctl enable NetworkManager-dispatcher.service
+# Enable this service
+systemctl enable autohotspot.service

--- a/src/modules/hotspot_nm/start_chroot_script
+++ b/src/modules/hotspot_nm/start_chroot_script
@@ -11,12 +11,14 @@ SCRIPT_FILE="/usr/bin/autohotspotNM"
 
 source /common.sh
 
-# Install dnsmasq-base as dhcp server and avahi-daemon as it's not included
-# on armbian. NOTE: It's required for this module to be loaded BEFORE the
-# 'ratos' module, otherwise the build will fail as ratos includes a modified
-# avahi-daemon.conf file and apt will interactively ask what to do, even if the
-# DEBIAN_FRONTEND is set to uninteractive.
-check_install_pkgs dnsmasq-base avahi-daemon
+# Install dnsmasq-base as dhcp server
+check_install_pkgs dnsmasq-base
+# Install avahi-daemon as it's not included in armbian
+# NOTE: It's required for this module to be installed answering 'no', as
+# otherwise the build might fail if an avahi-daemon.conf file is present
+# as apt will interactively ask what to do, even if the DEBIAN_FRONTEND
+# is set to uninteractive.
+yes no | apt-get install -y avahi-daemon
 
 unpack /filesystem/root /
 

--- a/src/modules/rockpiconfig/filesystem/root/etc/udev/rules.d/90-gpio-spi.rules
+++ b/src/modules/rockpiconfig/filesystem/root/etc/udev/rules.d/90-gpio-spi.rules
@@ -1,0 +1,2 @@
+KERNEL=="spidev0.0", OWNER="root", GROUP="spi"
+KERNEL=="spidev0.1", OWNER="root", GROUP="spi"

--- a/src/modules/rockpiconfig/start_chroot_script
+++ b/src/modules/rockpiconfig/start_chroot_script
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+source /common.sh
+
+# Copy files over to /etc
+unpack /filesystem/root /
+
+# Armbian has just a few interesting motd
+rm -f /etc/update-motd.d/*-armbian-config /etc/update-motd.d/*-armbian-tips /etc/update-motd.d/*-armbian-header
+
+# Enable spi-dev overlay
+cat << EOF >> /boot/armbianEnv.txt
+overlays=spi-spidev w1-gpio
+param_spidev_spi_bus=1
+EOF
+
+# Add spi group
+groupadd -f --system spi
+usermod -a -G spi "${BASE_USER}"
+
+# Add pi user to groups
+usermod -a -G disk,audio,plugdev,games,users,systemd-journal,input,netdev,ssh "${BASE_USER}"
+
+# Patch sshd_config
+sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+sed -i 's/^X11Forwarding/#X11Forwarding/' /etc/ssh/sshd_config
+sed -i 's/^#MaxAuthTries 6/MaxAuthTries 3/' /etc/ssh/sshd_config
+
+# Patch Armbian's first login -- we're adding our own 'pi' user
+if [ -f "/root/.not_logged_in_yet" ]; then
+    rm -f /root/.not_logged_in_yet
+fi


### PR DESCRIPTION
Adds support for radxa's Rock Pi 4b/4b+ and Rock Pi 4 SE boards.
Based on [Armbian for Rock Pi 4](https://www.armbian.com/rockpi4/).

Requires wifi management with NetworkManager (Rat-OS/RatOS-configurator#11).
Requires a rename of `rpi_mcu` module to `host_computer_mcu` (Rat-OS/RatOS-configuration#132 & Rat-OS/RatOS#85).

**Note**: Because of this last requirement on Rat-OS/RatOS#85, the build for this PR will fail.