### PR TITLE
fix: update deprecated GitHub Actions and RatOS Configurator paths

### DIFF
--- a/.github/workflows/BuildImages.yml
+++ b/.github/workflows/BuildImages.yml
@@ -55,7 +55,7 @@ jobs:
         config: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Cache aptitude
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: repository/src/workspace/aptcache
           key: ${{ matrix.config }}-apt-get-${{ hashFiles('**/apt.txt') }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload failed Logfile
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-${{ steps.move-image.outputs.image }}.log
           path: repository/src/build.log
@@ -107,19 +107,19 @@ jobs:
           sha256sum ${{ steps.move-image.outputs.image }}.img.xz > ${{ steps.move-image.outputs.image }}.img.xz.sha256
 
       - name: Upload Compressed Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.move-image.outputs.image }}.img.xz
           path: ${{ steps.move-image.outputs.image }}.img.xz
 
       - name: Upload Compressed Image Checksum
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.move-image.outputs.image }}.img.xz.sha256
           path: ${{ steps.move-image.outputs.image }}.img.xz.sha256
 
       - name: Upload Image Checksum
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.move-image.outputs.image }}.img.sha256
           path: ${{ steps.move-image.outputs.image }}.img.sha256

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -194,7 +194,7 @@ jobs:
         config: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Cache aptitude
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: repository/src/workspace/aptcache
           key: ${{ runner.os }}-apt-get-${{ hashFiles('**/apt.txt') }}
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload failed Logfile
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-${{ steps.move-image.outputs.image }}.log
           path: repository/src/build.log

--- a/src/modules/ratos/config
+++ b/src/modules/ratos/config
@@ -16,7 +16,7 @@
 [ -n "$RATOS_THEME_SHIP" ] || RATOS_THEME_SHIP=https://github.com/Rat-OS/RatOS-theme.git
 [ -n "$RATOS_THEME_BRANCH" ] || RATOS_THEME_BRANCH=v2.1.x
 [ -n "$RATOS_CONFIGURATOR_SHIP" ] || RATOS_CONFIGURATOR_SHIP=https://github.com/Rat-OS/RatOS-configurator.git
-[ -n "$RATOS_CONFIGURATOR_BRANCH" ] || RATOS_CONFIGURATOR_BRANCH=v2.1.x-deployment
+[ -n "$RATOS_CONFIGURATOR_BRANCH" ] || RATOS_CONFIGURATOR_BRANCH=dev-deployment
 
 #### NOTE:
 #### python3-serial is a klipper requirement

--- a/src/modules/ratos/start_chroot_script
+++ b/src/modules/ratos/start_chroot_script
@@ -70,11 +70,11 @@ check_install_pkgs ${RATOS_DEPS}
 
 
 # Install RatOS Configurator
-sudo -u "${BASE_USER}" bash /home/"${BASE_USER}"/ratos-configurator/scripts/setup.sh
+sudo -u "${BASE_USER}" bash /home/"${BASE_USER}"/ratos-configurator/app/scripts/setup.sh
 
 # Start the configurator so extensions can access the API
 echo "Starting RatOS Configurator"
-pushd "/home/${BASE_USER}/ratos-configurator"
+pushd "/home/${BASE_USER}/ratos-configurator/app"
 sudo -u "${BASE_USER}" npm run start &
 # Wait for configurator to start
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Description

This PR fixes build failures caused by deprecated GitHub Actions and RatOS Configurator path issues.

## Changes Made

### GitHub Actions Updates
#### BuildImages.yml
- Updated `actions/cache@v2` → `actions/cache@v4` (line 58)
- Updated `actions/upload-artifact@v3` → `actions/upload-artifact@v4` (lines 91, 110, 116, 122)

#### Release.yml
- Updated `actions/cache@v2` → `actions/cache@v4` (line 197)
- Updated `actions/upload-artifact@v3` → `actions/upload-artifact@v4` (line 214)

### RatOS Configurator Updates
#### Switch to dev-deployment branch
- Changed from `v2.1.x-deployment` to `dev-deployment` branch
- The dev-deployment branch contains upstream fixes for template paths and CLI installation

#### Path Updates for dev-deployment structure
- Updated setup script path: `scripts/setup.sh` → `app/scripts/setup.sh`
- Updated npm working directory: `/ratos-configurator` → `/ratos-configurator/app`

## Testing

The changes have been tested and verified to work correctly on my [fork](https://github.com/pvyleta/RatOS/actions/runs/15946730886/job/44981712062)

Fixes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions to use the latest versions for improved reliability.
  * Updated RatOS Configurator setup to use new script paths and directories.
  * Changed default branch for RatOS Configurator to the development deployment branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->