### PR TITLE
Update START_CHAMBER_TEMP mapping docs for Prusa Slicer

### DIFF
--- a/site/docs/slicers.md
+++ b/site/docs/slicers.md
@@ -54,7 +54,7 @@ Make sure the box labeled "Emit temperature commands automatically" is **uncheck
 :::
 
 ```properties
-START_PRINT EXTRUDER_TEMP={first_layer_temperature[0]} EXTRUDER_OTHER_LAYER_TEMP={temperature[0]} BED_TEMP=[first_layer_bed_temperature] START_CHAMBER_TEMP=[chamber_temperature] CHAMBER_TEMP=[chamber_temperature] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}
+START_PRINT EXTRUDER_TEMP={first_layer_temperature[0]} EXTRUDER_OTHER_LAYER_TEMP={temperature[0]} BED_TEMP=[first_layer_bed_temperature] START_CHAMBER_TEMP=[chamber_minimal_temperature] CHAMBER_TEMP=[chamber_temperature] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}
 ```
 
 Start GCode for IDEX printers
@@ -64,7 +64,7 @@ Make sure the box labeled "Emit temperature commands automatically" is **uncheck
 :::
 
 ```properties
-START_PRINT EXTRUDER_TEMP={first_layer_temperature[0]},{first_layer_temperature[1]} EXTRUDER_OTHER_LAYER_TEMP={temperature[0]},{temperature[1]} BED_TEMP=[first_layer_bed_temperature] START_CHAMBER_TEMP=[chamber_temperature] CHAMBER_TEMP=[chamber_temperature] INITIAL_TOOL={initial_tool} TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}
+START_PRINT EXTRUDER_TEMP={first_layer_temperature[0]},{first_layer_temperature[1]} EXTRUDER_OTHER_LAYER_TEMP={temperature[0]},{temperature[1]} BED_TEMP=[first_layer_bed_temperature] START_CHAMBER_TEMP=[chamber_minimal_temperature] CHAMBER_TEMP=[chamber_temperature] INITIAL_TOOL={initial_tool} TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}
 ```
 
 End GCode


### PR DESCRIPTION
I reported an issue and later found that the custom start g-code in the documentation uses `chamber_temperature` for both `START_CHAMBER_TEMP` and `CHAMBER_TEMP`, when there is a `chamber_minimal_temperature` meant for `START_CHAMBER_TEMP`, so I updated the docs to reflect this. Also, it appears that the SuperSlicer documentation already has the correct mapping.

https://discord.com/channels/582187371529764864/1441546673104097350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated START_PRINT macro examples to reference the correct chamber temperature source for single-toolhead and IDEX variant configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->