### PR TITLE
Chore node24 build migration

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,21 +11,31 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - name: Checkout
+        uses: actions/checkout@v6
         with:
-          version: 9.14.2
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
+          package_json_file: site/package.json
+          cache_dependency_path: site/pnpm-lock.yaml
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.
-          cache: 'pnpm'
-          cache-dependency-path: site/pnpm-lock.yaml
+          node-version: 24
 
       - name: Build website
         working-directory: site
         run: |
           pnpm install --frozen-lockfile
           pnpm run build
+
+      - name: Commit changes
+        id: extract_repo_name
+        run: |
+          # Extract only the repo name from 'owner/repo-name'
+          echo "repo_name=$(echo "${{ github.repository }}" | cut -d'/' -f2)" >> "$GITHUB_OUTPUT"
+
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
@@ -34,5 +44,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docs
-          user_name: Mikkel Schmidt
-          user_email: mikkel.schmidt@gmail.com
+          user_name: ${{ steps.extract_repo_name.outputs.repo_name }}
+          user_email: actions@github.com

--- a/site/package.json
+++ b/site/package.json
@@ -69,5 +69,6 @@
 			"last 1 firefox version",
 			"last 1 safari version"
 		]
-	}
+	},
+	"packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f"
 }

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@swc/core': true
+  '@tsparticles/engine': true
+  core-js: true
+  core-js-pure: true
+  sharp: true


### PR DESCRIPTION
Updates the docs site to use node v24 and specific version of pnpm.  Use `corepack enable` to allow it to manage the pnpm version, and then run `corepack install` locally for it to install the correct version of `pnpm` specified in the `package.json`

This also updates the committer information in the deploy action to use the repository name and the `actions@github.lcom` email address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated site deployment workflow to use newer tooling, enable pnpm caching, and run builds in the site workspace.
  * Made deploy commit author use the repository name and a generic actions email.
  * Added package manager metadata for the site and adjusted JSON structure for validity.
  * Refined workspace build allowlist to ensure required native and core packages build reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rat-OS/RatOS/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->