### PR TITLE
feat: add Raspberry Pi 5 support

### DIFF
--- a/.github/workflow_config.yml
+++ b/.github/workflow_config.yml
@@ -24,7 +24,7 @@ buildtest:
   # - orangepi/orangepi_zero2
   # Raspberry Pi OS based images
   - raspberry/rpi32
-  # - raspberry/rpi64
+  - raspberry/rpi64
   - raspberry/opicm4
 
 # This is used to setup release build chain.
@@ -39,5 +39,5 @@ release:
   # - orangepi/orangepi_zero2
   # Raspberry Pi OS based images
   - raspberry/rpi32
-  # - raspberry/rpi64
+  - raspberry/rpi64
   - raspberry/opicm4

--- a/config/raspberry/rpi64
+++ b/config/raspberry/rpi64
@@ -3,13 +3,11 @@
 
 BASE_ARCH="arm64"
 
-# Keep for Bookworm template
-# DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.sha256"
-# DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.torrent"
-
-# New locations after Bullseye turned into 'oldstable'
-DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2023-10-10/2023-05-03-raspios-bullseye-arm64-lite.img.xz.sha256"
-DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2023-10-10/2023-05-03-raspios-bullseye-arm64-lite.img.xz.torrent"
+# Rolling current-release image. Required for Raspberry Pi 5 support -
+# the previously pinned 2023-05-03 Bullseye image predates Pi 5 hardware
+# support entirely and cannot boot on a Pi 5.
+DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.sha256"
+DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.torrent"
 
 
 # export variables

--- a/src/modules/crowsnest/start_chroot_script
+++ b/src/modules/crowsnest/start_chroot_script
@@ -23,7 +23,9 @@ CN_BUILD_PACKAGE_FILE="/tmp/cn_packages.lst"
 
 # Helper Func
 is_raspbian() {
-    if [[ -f /boot/config.txt ]] && [[ -f /etc/rpi-issue ]]; then
+    # config.txt lives at /boot on Bullseye/Bookworm-legacy and at
+    # /boot/firmware on Bookworm+ (see piconfig module for the same check).
+    if { [[ -f /boot/config.txt ]] || [[ -f /boot/firmware/config.txt ]]; } && [[ -f /etc/rpi-issue ]]; then
         echo "1"
     else
         echo "0"

--- a/src/modules/klipperscreen/start_chroot_script
+++ b/src/modules/klipperscreen/start_chroot_script
@@ -17,9 +17,9 @@ echo needs_root_rights=yes>>/etc/X11/Xwrapper.config
 
 echo_green "Installing KlipperScreen"
 
-cd /home/pi
+cd "/home/${BASE_USER}"
 gitclone KLIPPERSCREEN KlipperScreen
-cd /home/pi/KlipperScreen
+cd "/home/${BASE_USER}/KlipperScreen"
 sudo -u "${BASE_USER}" NETWORK="skipnetworkmanagerinstall" ./scripts/KlipperScreen-install.sh
 
 # Mute output from klipperscreen service

--- a/src/modules/piconfig/filesystem/tmp/msos_config.txt
+++ b/src/modules/piconfig/filesystem/tmp/msos_config.txt
@@ -43,6 +43,10 @@ gpu_mem=256
 ## BTT Pi TFT's touch don't work with KMS on pi4 so we use FKMS for now.
 dtoverlay=vc4-fkms-v3d
 
+[pi5]
+## Pi 5 always uses KMS and manages GPU memory itself - no gpu_mem/dtoverlay
+## split needed here, unlike earlier models.
+
 [all]
 
 ## SPI Interface is enabled by default for Input Shaper

--- a/src/modules/piconfig/start_chroot_script
+++ b/src/modules/piconfig/start_chroot_script
@@ -20,6 +20,16 @@ fi
 source /common.sh
 install_cleanup_trap
 
+## Raspberry Pi OS Bookworm+ moved config.txt/cmdline.txt from /boot to
+## /boot/firmware (the previous Bullseye base image used /boot directly).
+## Detect the real location so this module keeps working across base images.
+if [[ -f /boot/firmware/config.txt ]]; then
+    PICONFIG_CONFIG_TXT_FILE="/boot/firmware/config.txt"
+    PICONFIG_CMDLINE_TXT_FILE="/boot/firmware/cmdline.txt"
+    PICONFIG_CONFIG_BAK_FILE="/boot/firmware/config.txt.backup"
+    PICONFIG_CMDLINE_BAK_FILE="/boot/firmware/cmdline.txt.backup"
+fi
+
 # Step 1: Copy msos_config.txt
 echo_green "Copying temporary file ..."
 unpack /filesystem/tmp /tmp root
@@ -81,10 +91,20 @@ systemctl_if_exists disable bluealsa.service
 
 
 # Step 11: Increase swapfile size
+# Raspberry Pi OS Trixie replaced dphys-swapfile with rpi-swap; handle both.
 if [[ -f "${PICONFIG_SWAP_CONF_FILE}" ]]; then
     echo_green "Increasing swap file size to ${PICONFIG_SWAP_SIZE} Mb. Limit to ${PICONFIG_SWAP_MAX} Mb"
     sed -i 's/^CONF_SWAPSIZE.*/'CONF_SWAPSIZE="${PICONFIG_SWAP_SIZE}"'/' "${PICONFIG_SWAP_CONF_FILE}"
     sed -i 's/^#CONF_MAXSWAP.*/'CONF_MAXSWAP="${PICONFIG_SWAP_MAX}"'/' "${PICONFIG_SWAP_CONF_FILE}"
+elif dpkg-query -s rpi-swap &>/dev/null; then
+    echo_green "Configuring swap (rpi-swap): ${PICONFIG_SWAP_SIZE} MiB, max ${PICONFIG_SWAP_MAX} MiB"
+    mkdir -p /etc/rpi/swap.conf.d
+    cat > /etc/rpi/swap.conf.d/10-ratos.conf << EOF
+# Managed by RatOS build - swap size tuning
+[File]
+FixedSizeMiB=${PICONFIG_SWAP_SIZE}
+MaxSizeMiB=${PICONFIG_SWAP_MAX}
+EOF
 fi
 
 # Step 12: Enable autologin (required for Pi3's, Pi4's do this by default, for some reason)
@@ -100,3 +120,21 @@ EOF
 echo_green "Generating and setting default locale to en_US.UTF-8..."
 # Use en_US.UTF-8 as default locale
 raspi-config nonint do_change_locale en_US.UTF-8
+
+# Step 14: Provision the default user account and enable SSH.
+# Bullseye images shipped a baked-in "pi" account; Bookworm+ does not, so it
+# has to be provisioned in-chroot via raspberrypi-sys-mods' userconf-pi (the
+# same mechanism Raspberry Pi Imager's "customize" flow uses).
+if [ -f /usr/lib/userconf-pi/userconf ]; then
+    echo_green "Provisioning default user ${BASE_USER}..."
+    hash="$(echo "${BASE_PASSWORD:-raspberry}" | openssl passwd -6 -stdin)"
+    /usr/lib/userconf-pi/userconf "${BASE_USER}" "${hash}"
+fi
+systemctl_if_exists disable userconfig.service
+
+echo_green "Enabling SSH..."
+if [ -f /usr/lib/raspberrypi-sys-mods/imager_custom ]; then
+    /usr/lib/raspberrypi-sys-mods/imager_custom enable_ssh
+else
+    systemctl_if_exists enable ssh
+fi

--- a/src/modules/rpi_mcu/start_chroot_script
+++ b/src/modules/rpi_mcu/start_chroot_script
@@ -9,22 +9,20 @@ install_cleanup_trap
 
 echo_green "Installing RPI MCU service"
 
-pushd /home/pi/klipper
+pushd "/home/${BASE_USER}/klipper"
 echo "flashing rpi-mcu"
-cp -f /home/pi/printer_data/config/RatOS/boards/rpi/firmware.config /home/pi/klipper/.config
+cp -f "/home/${BASE_USER}/printer_data/config/RatOS/boards/rpi/firmware.config" "/home/${BASE_USER}/klipper/.config"
 make olddefconfig
 make clean
 # Reset ownership so make flash doesn't complain
-chown pi:pi -R /home/pi/klipper
+chown "${BASE_USER}:${BASE_USER}" -R "/home/${BASE_USER}/klipper"
 make flash
 popd
 
-pushd /home/${BASE_USER}/klipper
+pushd "/home/${BASE_USER}/klipper"
 sudo cp "./scripts/klipper-mcu.service" /etc/systemd/system/klipper_mcu.service
 sudo systemctl enable klipper_mcu.service
 popd
 
-
-
 # Reset ownership
-chown pi:pi -R /home/pi/klipper
+chown "${BASE_USER}:${BASE_USER}" -R "/home/${BASE_USER}/klipper"

--- a/src/modules/udev_fix/start_chroot_script
+++ b/src/modules/udev_fix/start_chroot_script
@@ -36,6 +36,9 @@ if [[ -f /etc/armbian.txt ]]; then
 fi
 
 # Step 2: Fix broken udev (remove after debian releases patch)
+# NOTE: the 'deb11u2' match below is Bullseye-specific and intentionally
+# scopes this fix to that release - the bug is fixed upstream on Bookworm/
+# Trixie, so this is a deliberate no-op there, not dead code to remove.
 UDEV_PKG_VERSION="$(dpkg-query -s udev | grep "Version" | sed 's/Version\: //')"
 
 if [[ -n "${UDEV_PKG_VERSION}" ]] && [[ "${UDEV_PKG_VERSION}" =~ "deb11u2" ]]; then


### PR DESCRIPTION
Un-pins the Raspberry Pi 64-bit build from a hardcoded 2023-05-03 Bullseye image (which predates Pi 5 hardware support entirely) to a rolling current Raspberry Pi OS release, and updates the Raspberry Pi provisioning scripts for the Bookworm/Trixie-era changes that come with it:

- boot partition moved from /boot to /boot/firmware
- no baked-in default user account (now provisioned via userconf-pi)
- dphys-swapfile replaced by rpi-swap on Trixie
- add a [pi5] config.txt model-filter section

Also fixes a couple of scripts that hardcoded the pi user/home directory instead of using ${BASE_USER}, and re-enables the raspberry/rpi64 target in CI (previously disabled).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Raspberry Pi 64-bit builds and releases.
  * Added support for Raspberry Pi OS current-release images, including Raspberry Pi 5 boot layouts.
  * Improved Raspberry Pi 5 configuration, swap management, SSH setup, and default-user provisioning.
* **Bug Fixes**
  * Improved compatibility with newer Raspberry Pi OS filesystem layouts.
  * Fixed installation and MCU flashing workflows for custom base users instead of assuming the `pi` account.
  * Clarified legacy Bullseye-specific udev handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->